### PR TITLE
#2: Add CI build

### DIFF
--- a/.github/workflows/javadoc_publish.yml
+++ b/.github/workflows/javadoc_publish.yml
@@ -12,8 +12,19 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+          cache: 'maven'
       - name: Create JavaDoc
-        run: mvn javadoc:javadoc
+        run: |
+          mvn --batch-mode javadoc:javadoc \
+              -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+              -DtrimStackTrace=false
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/javadoc_publish.yml
+++ b/.github/workflows/javadoc_publish.yml
@@ -10,6 +10,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
       - name: Create JavaDoc
         run: mvn javadoc:javadoc
       - name: Deploy

--- a/.github/workflows/javadoc_publish.yml
+++ b/.github/workflows/javadoc_publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request: # TODO: Don't forget to remove
 
 jobs:
   publish:

--- a/.github/workflows/javadoc_publish.yml
+++ b/.github/workflows/javadoc_publish.yml
@@ -1,0 +1,18 @@
+name: Deploy Javadoc
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish JavaDoc
+        uses: MathieuSoysal/Javadoc-publisher.yml@v2.0.4
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          javadoc-branch: javadoc
+          java-version: 17
+          target-folder: javadoc

--- a/.github/workflows/javadoc_publish.yml
+++ b/.github/workflows/javadoc_publish.yml
@@ -9,10 +9,14 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Publish JavaDoc
-        uses: MathieuSoysal/Javadoc-publisher.yml@v2.0.4
+      - name: Create JavaDoc
+        run: mvn javadoc:javadoc
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          javadoc-branch: javadoc
-          java-version: 17
-          target-folder: javadoc
+          branch: gh-pages
+          folder: target/site/apidocs
+          target-folder: .
+          clean: true
+          single-commit: true
+          force: true

--- a/.github/workflows/javadoc_publish.yml
+++ b/.github/workflows/javadoc_publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request: # TODO: Don't forget to remove
 
 jobs:
   publish:

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ This project contains the API required to build [User Defined Functions](https:/
 
 User Defined Functions extend Exasol with functions and scripts that can be called from within SQL statements.
 
-## Information for Users
+## Information for API Users
 
-Please check out our [Java tutorials](https://github.com/exasol/exasol-java-tutorial) for examples of how to build, test and run Java UDFs.
+* [API documentation as JavaDoc](https://exasol.github.io/udf-api-java/javadoc/)
+* [Java tutorials](https://github.com/exasol/exasol-java-tutorial) with examples of how to build, test and run Java UDFs
 
 ## Additional Information
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ User Defined Functions extend Exasol with functions and scripts that can be call
 
 ## Information for API Users
 
-* [API documentation as JavaDoc](https://exasol.github.io/udf-api-java/javadoc/)
+* [API documentation as JavaDoc](https://exasol.github.io/udf-api-java/)
 * [Java tutorials](https://github.com/exasol/exasol-java-tutorial) with examples of how to build, test and run Java UDFs
 
 ## Additional Information

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ User Defined Functions extend Exasol with functions and scripts that can be call
 
 ## Information for API Users
 
-* [API documentation as JavaDoc](https://exasol.github.io/udf-api-java/)
+* [API documentation as JavaDoc](https://exasol.github.io/udf-api-java)
 * [Java tutorials](https://github.com/exasol/exasol-java-tutorial) with examples of how to build, test and run Java UDFs
 
 ## Additional Information

--- a/doc/changes/changes_1.0.0.md
+++ b/doc/changes/changes_1.0.0.md
@@ -1,4 +1,4 @@
-# Exasol UDF API for Java 1.0.0, released 2022-11-09
+# Exasol UDF API for Java 1.0.0, released 2022-11-10
 
 Code name: Extracted UDF API from script-languages
 

--- a/doc/changes/changes_1.0.0.md
+++ b/doc/changes/changes_1.0.0.md
@@ -6,10 +6,14 @@ Code name: Extracted UDF API from script-languages
 
 This is the first separate release of the UDF API. We extracted it from the project [script-languages release 2019-07-26](https://github.com/exasol/script-languages/releases/tag/20190726). Note that the API has been stable for a very long time and this extracted release did not change the API either. We just extracted it to enable a better way of releasing and distributing the API in the future.
 
+We also updated the JavaDoc. You can read the [JavaDoc online](https://exasol.github.io/udf-api-java/javadoc/).
+
 ## Refactoring
 
 * #1: Extracted UDF API from `script-languages`
+* #2: Added CI build
 * #5: Fixed JavaDoc and code smells
+* #7: Added integration test
 
 ## Dependency Updates
 

--- a/doc/changes/changes_1.0.0.md
+++ b/doc/changes/changes_1.0.0.md
@@ -6,7 +6,7 @@ Code name: Extracted UDF API from script-languages
 
 This is the first separate release of the UDF API. We extracted it from the project [script-languages release 2019-07-26](https://github.com/exasol/script-languages/releases/tag/20190726). Note that the API has been stable for a very long time and this extracted release did not change the API either. We just extracted it to enable a better way of releasing and distributing the API in the future.
 
-We also updated the JavaDoc. You can read the [JavaDoc online](https://exasol.github.io/udf-api-java/javadoc/).
+We also updated the JavaDoc. You can read the [JavaDoc online](https://exasol.github.io/udf-api-java/).
 
 ## Refactoring
 

--- a/doc/changes/changes_1.0.0.md
+++ b/doc/changes/changes_1.0.0.md
@@ -6,7 +6,7 @@ Code name: Extracted UDF API from script-languages
 
 This is the first separate release of the UDF API. We extracted it from the project [script-languages release 2019-07-26](https://github.com/exasol/script-languages/releases/tag/20190726). Note that the API has been stable for a very long time and this extracted release did not change the API either. We just extracted it to enable a better way of releasing and distributing the API in the future.
 
-We also updated the JavaDoc. You can read the [JavaDoc online](https://exasol.github.io/udf-api-java/).
+We also updated the JavaDoc. You can read the [JavaDoc online](https://exasol.github.io/udf-api-java).
 
 ## Refactoring
 

--- a/src/main/java/com/exasol/ExaConnectionInformation.java
+++ b/src/main/java/com/exasol/ExaConnectionInformation.java
@@ -40,7 +40,7 @@ public interface ExaConnectionInformation {
      * Get the connection password.
      * 
      * @return password of the connection, i.e. the part that follows the {@code IDENTIFIED BY} keyword in the {@code
-     * CREATE CONNECTION command
+     * CREATE CONNECTION} command
      */
     public String getPassword();
 }

--- a/src/test/java/com/exasol/test/ExaMetadataIT.java
+++ b/src/test/java/com/exasol/test/ExaMetadataIT.java
@@ -1,3 +1,5 @@
+package com.exasol.test;
+
 import com.exasol.containers.ExasolContainer;
 import com.exasol.dbbuilder.dialects.Schema;
 import com.exasol.dbbuilder.dialects.exasol.ExasolObjectFactory;


### PR DESCRIPTION
A couple of CI build steps were already present (thanks to GitHub Keeper). I added one that pulishes the JavaDoc on GitHub pages.