### PR TITLE
Fixing javadoc publish worklfow for project

### DIFF
--- a/.github/workflows/javadoc_publish.yml
+++ b/.github/workflows/javadoc_publish.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: 11
-          cache: 'maven'
+          distribution: temurin
+          java-version: '17'
+          cache: maven
       - name: Create JavaDoc
         run: |
           mvn --batch-mode javadoc:javadoc \

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,9 @@
 {
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.organizeImports": true,
-    "source.generate.finalModifiers": true,
-    "source.fixAll": true
+    "source.organizeImports": "explicit",
+    "source.generate.finalModifiers": "explicit",
+    "source.fixAll": "explicit"
   },
   "java.codeGeneration.useBlocks": true,
   "java.saveActions.organizeImports": true,

--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,5 +1,6 @@
 # Changes
 
+* [1.0.8](changes_1.0.8.md)
 * [1.0.7](changes_1.0.7.md)
 * [1.0.6](changes_1.0.6.md)
 * [1.0.5](changes_1.0.5.md)

--- a/doc/changes/changes_1.0.8.md
+++ b/doc/changes/changes_1.0.8.md
@@ -1,0 +1,10 @@
+# Exasol UDF API for Java 1.0.8, released 2025-??-??
+
+Code name:
+
+## Summary
+
+## Features
+
+* ISSUE_NUMBER: description
+

--- a/pk_generated_parent.pom
+++ b/pk_generated_parent.pom
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.exasol</groupId>
     <artifactId>udf-api-java-generated-parent</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <packaging>pom</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>udf-api-java</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
     <name>Exasol UDF API for Java</name>
     <description>Interface between User Defined Functions (UDFs) written in Java and the Exasol database.</description>
     <url>https://github.com/exasol/udf-api-java/</url>
@@ -116,7 +116,7 @@
     <parent>
         <artifactId>udf-api-java-generated-parent</artifactId>
         <groupId>com.exasol</groupId>
-        <version>1.0.7</version>
+        <version>1.0.8</version>
         <relativePath>pk_generated_parent.pom</relativePath>
     </parent>
 </project>


### PR DESCRIPTION
While doing the latest release, we found out there was in issue with the javadoc publish step being outdated. This is an attempt at fixing the workflow