### PR TITLE
Javadoc generation workflow: Fix publish step path

### DIFF
--- a/.github/workflows/javadoc_publish.yml
+++ b/.github/workflows/javadoc_publish.yml
@@ -29,7 +29,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
-          folder: target/site/apidocs
+          folder: target/reports/apidocs
           target-folder: .
           clean: true
           single-commit: true


### PR DESCRIPTION
Alter the path where the report is generated